### PR TITLE
Add Graph Normalization and merging

### DIFF
--- a/felis/__init__.py
+++ b/felis/__init__.py
@@ -25,3 +25,26 @@ try:
 except DistributionNotFound:
     # package is not installed
     __version__ = "source"
+
+DEFAULT_CONTEXT = {
+    "@vocab": "http://lsst.org/felis/",
+    "mysql": "http://mysql.com/",
+    "postgres": "http://posgresql.org/",
+    "oracle": "http://oracle.com/database/",
+    "sqlite": "http://sqlite.org/",
+    "fits": "http://fits.gsfc.nasa.gov/FITS/4.0/",
+    "ivoa": "http://ivoa.net/rdf/",
+    "votable": "http://ivoa.net/rdf/VOTable/",
+    "tap": "http://ivoa.net/documents/TAP/"
+}
+
+DEFAULT_FRAME = {
+    "@context": DEFAULT_CONTEXT,
+    "@type": "felis:Schema",
+    "tables": {
+        "@container": "@list",
+        "columns": {
+            "@container": "@list"
+        }
+    }
+}

--- a/felis/cli.py
+++ b/felis/cli.py
@@ -17,14 +17,17 @@
 # You should have received a copy of the LSST License Statement and
 # the GNU General Public License along with this program.  If not,
 # see <http://www.lsstcorp.org/LegalNotices/>.
+import json
 
 import click
 import yaml
+from pyld import jsonld
 from sqlalchemy import create_engine
 
 from .model import Visitor
 from .tap import TapLoadingVisitor, Tap11Base
-from . import __version__
+from .utils import ReorderingVisitor
+from . import __version__, DEFAULT_CONTEXT, DEFAULT_FRAME
 
 
 @click.group()
@@ -103,40 +106,60 @@ def load_tap(engine_url, schema_name, catalog_name, dry_run, file):
     tap_visitor.visit_schema(schema_obj)
 
 
-# @cli.command("normalize")
-# @click.argument('file', type=click.File())
-# def normalize(file):
-#     """Normalize a Felis FILE.
-#     This command loads the associated TAP metadata from a Felis FILE
-#     to the TAP_SCHEMA tables."""
-#     schema_obj = yaml.load(file)
-#     schema_obj["@type"] = "felis:Schema"
-#     # Force Context and Schema Type
-#     schema_obj["@context"] = {
-#         "@vocab": "http://lsst.org/felis/",
-#         "mysql": "http://mysql.com/",
-#         "postgres": "http://posgresql.org/",
-#         "oracle": "http://oracle.com/database/",
-#         "sqlite": "http://sqlite.org/",
-#         "fits": "http://fits.gsfc.nasa.gov/FITS/4.0/",
-#         "ivoa": "http://ivoa.net/rdf/",
-#         "votable": "http://ivoa.net/rdf/VOTable/",
-#         "tap": "http://ivoa.net/documents/TAP/",
-#         "tables": {
-#             "@id": "felis:Table",
-#             "@container": "@list"
-#         },
-#         "columns": {
-#             "@id": "felis:Column",
-#             "@container": "@list"
-#         }
-#     }
-#     json.dump(schema_obj, open("output.jsonld", "w"), indent=4, sort_keys=True)
-#     from pyld import jsonld
-#     framed = jsonld.frame(schema_obj, DEFAULT_FRAME)
-#     print(json.dumps(framed, indent=2))
-#     compacted = jsonld.compact(framed, DEFAULT_CONTEXT)
-#     print(json.dumps(compacted, indent=2))
+@cli.command("normalize")
+@click.argument('file', type=click.File())
+def normalize(file):
+    """Normalize a Felis FILE."""
+    schema_obj = yaml.load(file)
+    schema_obj["@type"] = "felis:Schema"
+    # Force Context and Schema Type
+    schema_obj["@context"] = DEFAULT_CONTEXT
+    expanded = jsonld.expand(schema_obj)
+    normalized = _normalize(expanded)
+    _dump(normalized)
+
+
+@cli.command("merge")
+@click.argument('files', nargs=-1, type=click.File())
+def merge(files):
+    """Merge a set of Feils FILES"""
+    graph = []
+    for file in files:
+        schema_obj = yaml.load(file)
+        schema_obj["@type"] = "felis:Schema"
+        # Force Context and Schema Type
+        schema_obj["@context"] = DEFAULT_CONTEXT
+        expanded = jsonld.expand(schema_obj)
+        graph.extend(expanded)
+
+    merged = {"@context": DEFAULT_CONTEXT,
+              "@graph": graph}
+    normalized = _normalize(merged)
+    _dump(normalized)
+
+
+def _dump(obj):
+    class OrderedDumper(yaml.Dumper):
+        pass
+
+    def _dict_representer(dumper, data):
+        return dumper.represent_mapping(
+            yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+            data.items())
+
+    OrderedDumper.add_representer(dict, _dict_representer)
+    print(yaml.dump(obj, Dumper=OrderedDumper, default_flow_style=False))
+
+
+def _normalize(schema_obj):
+    framed = jsonld.frame(schema_obj, DEFAULT_FRAME)
+    compacted = jsonld.compact(framed, DEFAULT_CONTEXT)
+    graph = compacted["@graph"]
+    if not isinstance(graph, list):
+        graph = [graph]
+    graph = [ReorderingVisitor(add_type=True).visit_schema(schema_obj) for schema_obj in graph]
+    compacted["@graph"] = graph if len(graph) > 1 else graph[0]
+    return compacted
 
 
 class InsertDump:

--- a/felis/cli.py
+++ b/felis/cli.py
@@ -153,10 +153,8 @@ def _dump(obj):
 
 def _normalize(schema_obj):
     framed = jsonld.frame(schema_obj, DEFAULT_FRAME)
-    compacted = jsonld.compact(framed, DEFAULT_CONTEXT)
+    compacted = jsonld.compact(framed, DEFAULT_CONTEXT, options=dict(graph=True))
     graph = compacted["@graph"]
-    if not isinstance(graph, list):
-        graph = [graph]
     graph = [ReorderingVisitor(add_type=True).visit_schema(schema_obj) for schema_obj in graph]
     compacted["@graph"] = graph if len(graph) > 1 else graph[0]
     return compacted

--- a/felis/utils.py
+++ b/felis/utils.py
@@ -1,0 +1,85 @@
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+
+class ReorderingVisitor:
+
+    def __init__(self, add_type=False):
+        """
+        A visitor that reorders and optionall adds the "@type"
+        :param add_type: If true, add the "@type" if it doesn't exist
+        """
+        self.add_type = add_type
+
+    def visit_schema(self, schema_obj):
+        """The input MUST be a normalized representation"""
+        # Override with default
+        tables = [self.visit_table(table_obj, schema_obj) for table_obj in schema_obj["tables"]]
+        schema_obj["tables"] = tables
+        if self.add_type:
+            schema_obj["@type"] = schema_obj.get("@type", "Schema")
+        return _new_order(schema_obj, ["@context", "name", "@id", "@type", "description",
+                                       "tables"])
+
+    def visit_table(self, table_obj, schema_obj):
+
+        columns = [self.visit_column(c, table_obj) for c in table_obj["columns"]]
+        primary_key = self.visit_primary_key(table_obj.get("primaryKey", []), table_obj)
+        constraints = [self.visit_constraint(c, table_obj) for c in table_obj.get("constraints",[])]
+        indexes = [self.visit_index(i, table_obj) for i in table_obj.get("indexes", [])]
+        table_obj["columns"] = columns
+        if primary_key:
+            table_obj["primaryKey"] = primary_key
+        if constraints:
+            table_obj["constraints"] = constraints
+        if indexes:
+            table_obj["indexes"] = indexes
+        if self.add_type:
+            table_obj["@type"] = table_obj.get("@type", "Table")
+        return _new_order(table_obj, ["name", "@id", "@type", "description",
+                                      "columns", "primaryKey", "constraints", "indexes"])
+
+    def visit_column(self, column_obj, table_obj):
+        if self.add_type:
+            column_obj["@type"] = column_obj.get("@type", "Column")
+        return _new_order(column_obj, ["name", "@id", "@type",  "description", "datatype"])
+
+    def visit_primary_key(self, primary_key_obj, table):
+        # FIXME: Handle Primary Keys
+        return primary_key_obj
+
+    def visit_constraint(self, constraint_obj, table):
+        # Type MUST be present... we can skip
+        return _new_order(constraint_obj, ["name", "@id", "@type", "description"])
+
+    def visit_index(self, index_obj, table):
+        if self.add_type:
+            index_obj["@type"] = index_obj.get("@type", "Index")
+        return _new_order(index_obj, ["name", "@id", "@type", "description"])
+
+
+def _new_order(obj, order):
+    reordered_object = {}
+    for name in order:
+        if name in obj:
+            reordered_object[name] = obj[name]
+    for key, value in obj.items():
+        if key not in reordered_object:
+            reordered_object[key] = value
+    return reordered_object


### PR DESCRIPTION
This adds some primitive operations on the graph that will aid in processing the descriptions from merged graphs.

Merging graphs is useful for specifying additional relationships across multiple files.

A merged graph will allow easy processing for validation of relationships across the documents; for example, we can query:

```
SELECT ?dpdd_rule_name WHERE {
<felis:Column> <prov:wasDerivedFrom> ?dpdd_rule_id .
?dpdd_rule_id <name> ?dpdd_rule_name .
}
```
