### PR TITLE
Add table name overrides to TAP schema names. Implement felis file merging.

### DIFF
--- a/examples/merge/point-extra.yml
+++ b/examples/merge/point-extra.yml
@@ -1,0 +1,8 @@
+---
+"@graph":
+  - "@id": "#Geometry_Point.ra"
+    ivoa:ucd: pos.eq.ra;meta.main
+    fits:tunit: deg
+  - "@id": "#Geometry_Point.dec"
+    ivoa:ucd: pos.eq.dec;meta.main
+    fits:tunit: deg

--- a/examples/merge/point.yml
+++ b/examples/merge/point.yml
@@ -1,0 +1,29 @@
+---
+name: Geometry
+"@id": "#Geometry"
+tables:
+- name: Point
+  "@id": "#Geometry_Point"
+  columns:
+    - name: ra
+      "@id": "#Geometry_Point.ra"
+      datatype: float
+    - name: dec
+      "@id": "#Geometry_Point.dec"
+      datatype: float
+- name: Line
+  "@id": "#Geometry_Line"
+  columns:
+    - name: ra0
+      "@id": "#Geometry_Line.ra0"
+      datatype: float
+    - name: dec0
+      "@id": "#Geometry_Line.dec0"
+      datatype: float
+  columns:
+    - name: ra1
+      "@id": "#Geometry_Line.ra1"
+      datatype: float
+    - name: dec1
+      "@id": "#Geometry_Line.dec1"
+      datatype: float

--- a/felis/__init__.py
+++ b/felis/__init__.py
@@ -35,16 +35,20 @@ DEFAULT_CONTEXT = {
     "fits": "http://fits.gsfc.nasa.gov/FITS/4.0/",
     "ivoa": "http://ivoa.net/rdf/",
     "votable": "http://ivoa.net/rdf/VOTable/",
-    "tap": "http://ivoa.net/documents/TAP/"
+    "tap": "http://ivoa.net/documents/TAP/",
+    "tables": {
+        "@container": "@list",
+        "@type": "@id",
+        "@id": "felis:Table"
+    },
+    "columns": {
+        "@container": "@list",
+        "@type": "@id",
+        "@id": "felis:Column"
+    }
 }
 
 DEFAULT_FRAME = {
     "@context": DEFAULT_CONTEXT,
     "@type": "felis:Schema",
-    "tables": {
-        "@container": "@list",
-        "columns": {
-            "@container": "@list"
-        }
-    }
 }

--- a/felis/cli.py
+++ b/felis/cli.py
@@ -26,12 +26,13 @@ from pyld import jsonld
 from sqlalchemy import create_engine
 
 from .model import Visitor, VisitorBase
-from .tap import TapLoadingVisitor, Tap11Base
+from .tap import TapLoadingVisitor, Tap11Base, init_tables
 from .utils import ReorderingVisitor
 from . import __version__, DEFAULT_CONTEXT, DEFAULT_FRAME
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("felis")
+
 
 @click.group()
 @click.version_option(__version__)
@@ -41,11 +42,10 @@ def cli():
 
 
 @cli.command("create-all")
-@click.option('--engine-url', envvar="ENGINE_URL", help="SQLAlchemy Engine URL")
-@click.option('--schema-name', help="Alternate Schema Name for Felis File")
-@click.option('--dry-run', is_flag=True, help="Dry Run Only. Prints out the DDL that would be "
-                                              "executed")
-@click.argument('file', type=click.File())
+@click.option("--engine-url", envvar="ENGINE_URL", help="SQLAlchemy Engine URL")
+@click.option("--schema-name", help="Alternate Schema Name for Felis File")
+@click.option("--dry-run", is_flag=True, help="Dry Run Only. Prints out the DDL that would be executed")
+@click.argument("file", type=click.File())
 def create_all(engine_url, schema_name, dry_run, file):
     """Create schema objects from the Felis FILE."""
 
@@ -69,23 +69,57 @@ def create_all(engine_url, schema_name, dry_run, file):
 
 
 @cli.command("init-tap")
-@click.argument('engine-url')
-def init_tap(engine_url):
+@click.option("--tap-schema-name", help="Alt Schema Name for TAP_SCHEMA")
+@click.option("--tap-schemas-table", help="Alt Table Name for TAP_SCHEMA.schemas")
+@click.option("--tap-tables-table", help="Alt Table Name for TAP_SCHEMA.tables")
+@click.option("--tap-columns-table", help="Alt Table Name for TAP_SCHEMA.columns")
+@click.option("--tap-keys-table", help="Alt Table Name for TAP_SCHEMA.keys")
+@click.option("--tap-key-columns-table", help="Alt Table Name for TAP_SCHEMA.key_columns")
+@click.argument("engine-url")
+def init_tap(
+    engine_url,
+    tap_schema_name,
+    tap_schemas_table,
+    tap_tables_table,
+    tap_columns_table,
+    tap_keys_table,
+    tap_key_columns_table,
+):
     """Initialize TAP 1.1 TAP_SCHEMA objects.
     Please verify the schema/catalog you are executing this in in your
     engine URL."""
     engine = create_engine(engine_url, echo=True)
+    init_tables(
+        tap_schema_name, tap_schemas_table, tap_tables_table, tap_columns_table, tap_keys_table, tap_key_columns_table
+    )
     Tap11Base.metadata.create_all(engine)
 
 
 @cli.command("load-tap")
-@click.option('--engine-url', envvar="ENGINE_URL", help="SQLAlchemy Engine URL to catalog")
-@click.option('--schema-name', help="Alternate Schema Name for Felis file")
-@click.option('--catalog-name', help="Catalog Name for Schema")
-@click.option('--dry-run', is_flag=True, help="Dry Run Only. Prints out the DDL that would be "
-                                              "executed")
-@click.argument('file', type=click.File())
-def load_tap(engine_url, schema_name, catalog_name, dry_run, file):
+@click.option("--engine-url", envvar="ENGINE_URL", help="SQLAlchemy Engine URL to catalog")
+@click.option("--schema-name", help="Alternate Schema Name for Felis file")
+@click.option("--catalog-name", help="Catalog Name for Schema")
+@click.option("--dry-run", is_flag=True, help="Dry Run Only. Prints out the DDL that would be executed")
+@click.option("--tap-schema-name", help="Alt Schema Name for TAP_SCHEMA")
+@click.option("--tap-schemas-table", help="Alt Table Name for TAP_SCHEMA.schemas")
+@click.option("--tap-tables-table", help="Alt Table Name for TAP_SCHEMA.tables")
+@click.option("--tap-columns-table", help="Alt Table Name for TAP_SCHEMA.columns")
+@click.option("--tap-keys-table", help="Alt Table Name for TAP_SCHEMA.keys")
+@click.option("--tap-key-columns-table", help="Alt Table Name for TAP_SCHEMA.key_columns")
+@click.argument("file", type=click.File())
+def load_tap(
+    engine_url,
+    schema_name,
+    catalog_name,
+    dry_run,
+    tap_schema_name,
+    tap_schemas_table,
+    tap_tables_table,
+    tap_columns_table,
+    tap_keys_table,
+    tap_key_columns_table,
+    file,
+):
     """Load TAP metadata from a Felis FILE.
     This command loads the associated TAP metadata from a Felis FILE
     to the TAP_SCHEMA tables."""
@@ -95,21 +129,25 @@ def load_tap(engine_url, schema_name, catalog_name, dry_run, file):
         engine = create_engine(engine_url)
     else:
         _insert_dump = InsertDump()
-        engine = create_engine(engine_url, strategy="mock", executor=_insert_dump.dump,
-                               paramstyle="pyformat")
+        engine = create_engine(engine_url, strategy="mock", executor=_insert_dump.dump, paramstyle="pyformat")
         # After the engine is created, update the executor with the dialect
         _insert_dump.dialect = engine.dialect
+    tap_tables = init_tables(
+        tap_schema_name, tap_schemas_table, tap_tables_table, tap_columns_table, tap_keys_table, tap_key_columns_table
+    )
 
     if engine_url == "sqlite://" and not dry_run:
         # In Memory SQLite - Mostly used to test
         Tap11Base.metadata.create_all(engine)
 
-    tap_visitor = TapLoadingVisitor(engine, catalog_name=catalog_name, schema_name=schema_name,
-                                    mock=dry_run)
+    tap_visitor = TapLoadingVisitor(
+        engine, catalog_name=catalog_name, schema_name=schema_name, mock=dry_run, tap_tables=tap_tables
+    )
     tap_visitor.visit_schema(schema_obj)
 
+
 @cli.command("basic-check")
-@click.argument('file', type=click.File())
+@click.argument("file", type=click.File())
 def basic_check(file):
     """Perform a basic check on a felis FILE.
     This performs a very check to ensure required fields are
@@ -125,9 +163,19 @@ def basic_check(file):
 
 
 @cli.command("normalize")
-@click.argument('file', type=click.File())
+@click.argument("file", type=click.File())
 def normalize(file):
-    """Normalize a Felis FILE."""
+    """Normalize a Felis FILE.
+    Takes a felis schema FILE, expands it (resolving the full URLs),
+    then compacts it, and finally produces output in the canonical
+    format.
+
+    (This is most useful in some debugging scenarios)
+
+    See Also:
+        https://json-ld.org/spec/latest/json-ld/#expanded-document-form
+        https://json-ld.org/spec/latest/json-ld/#compacted-document-form
+    """
     schema_obj = yaml.load(file, Loader=yaml.SafeLoader)
     schema_obj["@type"] = "felis:Schema"
     # Force Context and Schema Type
@@ -138,9 +186,14 @@ def normalize(file):
 
 
 @cli.command("merge")
-@click.argument('files', nargs=-1, type=click.File())
+@click.argument("files", nargs=-1, type=click.File())
 def merge(files):
-    """Merge a set of Feils FILES"""
+    """Merge a set of Feils FILES.
+
+    This will expand out the felis FILES so that it is easy to
+    override values (using @Id), then normalize to a single
+    output.
+    """
     graph = []
     for file in files:
         schema_obj = yaml.load(file, Loader=yaml.SafeLoader)
@@ -150,8 +203,7 @@ def merge(files):
         expanded = jsonld.expand(schema_obj)
         graph.extend(expanded)
 
-    merged = {"@context": DEFAULT_CONTEXT,
-              "@graph": graph}
+    merged = {"@context": DEFAULT_CONTEXT, "@graph": graph}
     normalized = _normalize(merged)
     _dump(normalized)
 
@@ -161,9 +213,7 @@ def _dump(obj):
         pass
 
     def _dict_representer(dumper, data):
-        return dumper.represent_mapping(
-            yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
-            data.items())
+        return dumper.represent_mapping(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, data.items())
 
     OrderedDumper.add_representer(dict, _dict_representer)
     print(yaml.dump(obj, Dumper=OrderedDumper, default_flow_style=False))
@@ -194,12 +244,12 @@ class InsertDump:
                 if isinstance(value, str):
                     new_params[key] = f"'{value}'"
                 elif value is None:
-                    new_params[key] = 'null'
+                    new_params[key] = "null"
                 else:
                     new_params[key] = value
 
             print(sql_str % new_params)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     cli()

--- a/felis/cli.py
+++ b/felis/cli.py
@@ -101,6 +101,7 @@ def init_tap(
 @click.option("--catalog-name", help="Catalog Name for Schema")
 @click.option("--dry-run", is_flag=True, help="Dry Run Only. Prints out the DDL that would be executed")
 @click.option("--tap-schema-name", help="Alt Schema Name for TAP_SCHEMA")
+@click.option("--tap-tables-postfix", help="Postfix for TAP table names")
 @click.option("--tap-schemas-table", help="Alt Table Name for TAP_SCHEMA.schemas")
 @click.option("--tap-tables-table", help="Alt Table Name for TAP_SCHEMA.tables")
 @click.option("--tap-columns-table", help="Alt Table Name for TAP_SCHEMA.columns")
@@ -113,6 +114,7 @@ def load_tap(
     catalog_name,
     dry_run,
     tap_schema_name,
+    tap_tables_postfix,
     tap_schemas_table,
     tap_tables_table,
     tap_columns_table,
@@ -133,7 +135,7 @@ def load_tap(
         # After the engine is created, update the executor with the dialect
         _insert_dump.dialect = engine.dialect
     tap_tables = init_tables(
-        tap_schema_name, tap_schemas_table, tap_tables_table, tap_columns_table, tap_keys_table, tap_key_columns_table
+        tap_schema_name, tap_tables_postfix, tap_schemas_table, tap_tables_table, tap_columns_table, tap_keys_table, tap_key_columns_table
     )
 
     if engine_url == "sqlite://" and not dry_run:

--- a/felis/tap.py
+++ b/felis/tap.py
@@ -21,24 +21,26 @@ QUALIFIED_TABLE_LENGTH = 3 * IDENTIFIER_LENGTH + 2
 
 def init_tables(
     tap_schema_name=None,
+    tap_tables_postfix=None,
     tap_schemas_table=None,
     tap_tables_table=None,
     tap_columns_table=None,
     tap_keys_table=None,
     tap_key_columns_table=None,
 ):
+    postfix = tap_tables_postfix or ""
     if tap_schema_name:
         Tap11Base.metadata.schema = tap_schema_name
 
     class Tap11Schemas(Tap11Base):
-        __tablename__ = tap_schemas_table or "schemas"
+        __tablename__ = (tap_schemas_table or "schemas") + postfix
         schema_name = Column(String(IDENTIFIER_LENGTH), primary_key=True, nullable=False)
         utype = Column(String(SIMPLE_FIELD_LENGTH))
         description = Column(String(TEXT_FIELD_LENGTH))
         schema_index = Column(Integer)
 
     class Tap11Tables(Tap11Base):
-        __tablename__ = tap_tables_table or "tables"
+        __tablename__ = (tap_tables_table or "tables") + postfix
         schema_name = Column(String(IDENTIFIER_LENGTH), nullable=False)
         table_name = Column(String(QUALIFIED_TABLE_LENGTH), nullable=False, primary_key=True)
         table_type = Column(String(SMALL_FIELD_LENGTH), nullable=False)
@@ -47,7 +49,7 @@ def init_tables(
         table_index = Column(Integer)
 
     class Tap11Columns(Tap11Base):
-        __tablename__ = tap_columns_table or "columns"
+        __tablename__ = (tap_columns_table or "columns") + postfix
         table_name = Column(String(QUALIFIED_TABLE_LENGTH), nullable=False, primary_key=True)
         column_name = Column(String(IDENTIFIER_LENGTH), nullable=False, primary_key=True)
         datatype = Column(String(SIMPLE_FIELD_LENGTH), nullable=False)
@@ -65,7 +67,7 @@ def init_tables(
         column_index = Column(Integer)
 
     class Tap11Keys(Tap11Base):
-        __tablename__ = tap_keys_table or "keys"
+        __tablename__ = (tap_keys_table or "keys") + postfix
         key_id = Column(String(IDENTIFIER_LENGTH), nullable=False, primary_key=True)
         from_table = Column(String(QUALIFIED_TABLE_LENGTH), nullable=False)
         target_table = Column(String(QUALIFIED_TABLE_LENGTH), nullable=False)
@@ -73,7 +75,7 @@ def init_tables(
         utype = Column(String(SIMPLE_FIELD_LENGTH))
 
     class Tap11KeyColumns(Tap11Base):
-        __tablename__ = tap_key_columns_table or "key_columns"
+        __tablename__ = (tap_key_columns_table or "key_columns") + postfix
         key_id = Column(String(IDENTIFIER_LENGTH), nullable=False, primary_key=True)
         from_column = Column(String(IDENTIFIER_LENGTH), nullable=False, primary_key=True)
         target_column = Column(String(IDENTIFIER_LENGTH), nullable=False, primary_key=True)

--- a/felis/tap.py
+++ b/felis/tap.py
@@ -1,8 +1,6 @@
-from typing import List
-
 import logging
 
-from sqlalchemy import Column, String, Integer
+from sqlalchemy import Column, String, Integer, Table
 from sqlalchemy.engine import Engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import Session, sessionmaker
@@ -21,76 +19,88 @@ TEXT_FIELD_LENGTH = 2048
 QUALIFIED_TABLE_LENGTH = 3 * IDENTIFIER_LENGTH + 2
 
 
-class Tap11Schemas(Tap11Base):
-    __tablename__ = "schemas"
-    schema_name = Column(String(IDENTIFIER_LENGTH), primary_key=True, nullable=False)
-    utype = Column(String(SIMPLE_FIELD_LENGTH))
-    description = Column(String(TEXT_FIELD_LENGTH))
-    schema_index = Column(Integer)
+def init_tables(
+    tap_schema_name=None,
+    tap_schemas_table=None,
+    tap_tables_table=None,
+    tap_columns_table=None,
+    tap_keys_table=None,
+    tap_key_columns_table=None,
+):
+    if tap_schema_name:
+        Tap11Base.metadata.schema = tap_schema_name
 
+    class Tap11Schemas(Tap11Base):
+        __tablename__ = tap_schemas_table or "schemas"
+        schema_name = Column(String(IDENTIFIER_LENGTH), primary_key=True, nullable=False)
+        utype = Column(String(SIMPLE_FIELD_LENGTH))
+        description = Column(String(TEXT_FIELD_LENGTH))
+        schema_index = Column(Integer)
 
-class Tap11Tables(Tap11Base):
-    __tablename__ = "tables"
-    schema_name = Column(String(IDENTIFIER_LENGTH), nullable=False)
-    table_name = Column(String(QUALIFIED_TABLE_LENGTH), nullable=False, primary_key=True)
-    table_type = Column(String(SMALL_FIELD_LENGTH), nullable=False)
-    utype = Column(String(SIMPLE_FIELD_LENGTH))
-    description = Column(String(TEXT_FIELD_LENGTH))
-    table_index = Column(Integer)
+    class Tap11Tables(Tap11Base):
+        __tablename__ = tap_tables_table or "tables"
+        schema_name = Column(String(IDENTIFIER_LENGTH), nullable=False)
+        table_name = Column(String(QUALIFIED_TABLE_LENGTH), nullable=False, primary_key=True)
+        table_type = Column(String(SMALL_FIELD_LENGTH), nullable=False)
+        utype = Column(String(SIMPLE_FIELD_LENGTH))
+        description = Column(String(TEXT_FIELD_LENGTH))
+        table_index = Column(Integer)
 
+    class Tap11Columns(Tap11Base):
+        __tablename__ = tap_columns_table or "columns"
+        table_name = Column(String(QUALIFIED_TABLE_LENGTH), nullable=False, primary_key=True)
+        column_name = Column(String(IDENTIFIER_LENGTH), nullable=False, primary_key=True)
+        datatype = Column(String(SIMPLE_FIELD_LENGTH), nullable=False)
+        arraysize = Column(String(10))
+        xtype = Column(String(SIMPLE_FIELD_LENGTH))
+        # Size is deprecated
+        # size = Column(Integer(), quote=True)
+        description = Column(String(TEXT_FIELD_LENGTH))
+        utype = Column(String(SIMPLE_FIELD_LENGTH))
+        unit = Column(String(SIMPLE_FIELD_LENGTH))
+        ucd = Column(String(SIMPLE_FIELD_LENGTH))
+        indexed = Column(Integer, nullable=False)
+        principal = Column(Integer, nullable=False)
+        std = Column(Integer, nullable=False)
+        column_index = Column(Integer)
 
-class Tap11Columns(Tap11Base):
-    __tablename__ = "columns"
-    table_name = Column(String(QUALIFIED_TABLE_LENGTH), nullable=False, primary_key=True)
-    column_name = Column(String(IDENTIFIER_LENGTH), nullable=False, primary_key=True)
-    datatype = Column(String(SIMPLE_FIELD_LENGTH), nullable=False)
-    arraysize = Column(String(10))
-    xtype = Column(String(SIMPLE_FIELD_LENGTH))
-    # Size is deprecated
-    # size = Column(Integer(), quote=True)
-    description = Column(String(TEXT_FIELD_LENGTH))
-    utype = Column(String(SIMPLE_FIELD_LENGTH))
-    unit = Column(String(SIMPLE_FIELD_LENGTH))
-    ucd = Column(String(SIMPLE_FIELD_LENGTH))
-    indexed = Column(Integer, nullable=False)
-    principal = Column(Integer, nullable=False)
-    std = Column(Integer, nullable=False)
-    column_index = Column(Integer)
+    class Tap11Keys(Tap11Base):
+        __tablename__ = tap_keys_table or "keys"
+        key_id = Column(String(IDENTIFIER_LENGTH), nullable=False, primary_key=True)
+        from_table = Column(String(QUALIFIED_TABLE_LENGTH), nullable=False)
+        target_table = Column(String(QUALIFIED_TABLE_LENGTH), nullable=False)
+        description = Column(String(TEXT_FIELD_LENGTH))
+        utype = Column(String(SIMPLE_FIELD_LENGTH))
 
+    class Tap11KeyColumns(Tap11Base):
+        __tablename__ = tap_key_columns_table or "key_columns"
+        key_id = Column(String(IDENTIFIER_LENGTH), nullable=False, primary_key=True)
+        from_column = Column(String(IDENTIFIER_LENGTH), nullable=False, primary_key=True)
+        target_column = Column(String(IDENTIFIER_LENGTH), nullable=False, primary_key=True)
 
-class Tap11Keys(Tap11Base):
-    __tablename__ = "keys"
-    key_id = Column(String(IDENTIFIER_LENGTH), nullable=False, primary_key=True)
-    from_table = Column(String(QUALIFIED_TABLE_LENGTH), nullable=False)
-    target_table = Column(String(QUALIFIED_TABLE_LENGTH), nullable=False)
-    description = Column(String(TEXT_FIELD_LENGTH))
-    utype = Column(String(SIMPLE_FIELD_LENGTH))
-
-
-class Tap11KeyColumns(Tap11Base):
-    __tablename__ = "key_columns"
-    key_id = Column(String(IDENTIFIER_LENGTH), nullable=False, primary_key=True)
-    from_column = Column(String(IDENTIFIER_LENGTH), nullable=False, primary_key=True)
-    target_column = Column(String(IDENTIFIER_LENGTH), nullable=False, primary_key=True)
+    return dict(
+        schemas=Tap11Schemas, tables=Tap11Tables, columns=Tap11Columns, keys=Tap11Keys, key_columns=Tap11KeyColumns
+    )
 
 
 class TapLoadingVisitor(VisitorBase):
-    def __init__(self, engine: Engine, catalog_name=None, schema_name=None, mock=False):
+    def __init__(self, engine: Engine, catalog_name=None, schema_name=None, mock=False, tap_tables=None):
         self.graph_index = {}
         self.catalog_name = catalog_name
         self.schema_name = schema_name
         self.engine = engine
         self.mock = mock
+        self.tables = tap_tables or init_tables()
 
     def visit_schema(self, schema_obj):
-        schema = Tap11Schemas()
+        schema = self.tables["schemas"]
         # Override with default
         self.schema_name = self.schema_name or schema_obj["name"]
 
         schema.schema_name = self._schema_name()
         schema.description = schema_obj.get("description")
         schema.utype = schema_obj.get("votable:utype")
-        schema.schema_index = int(schema_obj.get("tap:schema_index",0))
+        schema.schema_index = int(schema_obj.get("tap:schema_index", 0))
 
         if not self.mock:
             session: Session = sessionmaker(self.engine)()
@@ -105,21 +115,21 @@ class TapLoadingVisitor(VisitorBase):
         else:
             # Only if we are mocking (dry run)
             conn = self.engine
-            conn.execute(_insert(Tap11Schemas, schema))
+            conn.execute(_insert(self.tables["schemas"], schema))
             for table_obj in schema_obj["tables"]:
                 table, columns, keys, key_columns = self.visit_table(table_obj, schema_obj)
-                conn.execute(_insert(Tap11Tables, table))
+                conn.execute(_insert(self.tables["tables"], table))
                 for column in columns:
-                    conn.execute(_insert(Tap11Columns, column))
+                    conn.execute(_insert(self.tables["columns"], column))
                 for key in keys:
-                    conn.execute(_insert(Tap11Keys, key))
+                    conn.execute(_insert(self.tables["keys"], key))
                 for key_column in key_columns:
-                    conn.execute(_insert(Tap11KeyColumns, key_column))
+                    conn.execute(_insert(self.tables["key_columns"], key_column))
 
     def visit_table(self, table_obj, schema_obj):
         self.check_table(table_obj, schema_obj)
         table_id = table_obj["@id"]
-        table = Tap11Tables()
+        table = self.tables["tables"]()
         table.schema_name = self._schema_name()
         table.table_name = self._table_name(table_obj["name"])
         table.table_type = "table"
@@ -152,24 +162,28 @@ class TapLoadingVisitor(VisitorBase):
             # It is expected that both arraysize and length are fine for length types.
             arraysize = column_obj.get("votable:arraysize", column_obj.get("length"))
             if arraysize is None:
-                logger.warning(f"votable:arraysize and length for {_id} are None for type {datatype_name}. "
-                               "Using length \"*\". "
-                               "Consider setting `votable:arraysize` or `length`.")
+                logger.warning(
+                    f"votable:arraysize and length for {_id} are None for type {datatype_name}. "
+                    'Using length "*". '
+                    "Consider setting `votable:arraysize` or `length`."
+                )
         if datatype_name in DATETIME_TYPES:
             # datetime types really should have a votable:arraysize, because they are converted
             # to strings and the `length` is loosely to the string size
             if "votable:arraysize" not in column_obj:
-                logger.warning(f"votable:arraysize for {_id} is None for type {datatype_name}. "
-                               f"Using length \"*\". "
-                               "Consider setting `votable:arraysize` to an appropriate size for "
-                               "materialized datetime/timestamp strings.")
+                logger.warning(
+                    f"votable:arraysize for {_id} is None for type {datatype_name}. "
+                    f'Using length "*". '
+                    "Consider setting `votable:arraysize` to an appropriate size for "
+                    "materialized datetime/timestamp strings."
+                )
 
     def visit_column(self, column_obj, table_obj):
         self.check_column(column_obj, table_obj)
         column_id = column_obj["@id"]
         table_name = self._table_name(table_obj["name"])
 
-        column = Tap11Columns()
+        column = self.tables["columns"]()
         column.table_name = table_name
         column.column_name = column_obj["name"]
 
@@ -207,9 +221,7 @@ class TapLoadingVisitor(VisitorBase):
         if primary_key_obj:
             if not isinstance(primary_key_obj, list):
                 primary_key_obj = [primary_key_obj]
-            columns = [
-                self.graph_index[c_id] for c_id in primary_key_obj
-            ]
+            columns = [self.graph_index[c_id] for c_id in primary_key_obj]
             # if just one column and it's indexed, update the object
             if len(columns) == 1:
                 columns[0].indexed = 1
@@ -225,12 +237,8 @@ class TapLoadingVisitor(VisitorBase):
             description = constraint_obj.get("description")
             utype = constraint_obj.get("votable:utype")
 
-            columns: List[Tap11Columns] = [
-                self.graph_index[c_id] for c_id in constraint_obj.get("columns", [])
-            ]
-            refcolumns: List[Tap11Columns] = [
-                self.graph_index[c_id] for c_id in constraint_obj.get("referencedColumns", [])
-            ]
+            columns = [self.graph_index[c_id] for c_id in constraint_obj.get("columns", [])]
+            refcolumns = [self.graph_index[c_id] for c_id in constraint_obj.get("referencedColumns", [])]
 
             table_name = None
             for column in columns:
@@ -248,14 +256,14 @@ class TapLoadingVisitor(VisitorBase):
             first_column = columns[0]
             first_refcolumn = refcolumns[0]
 
-            key = Tap11Keys()
+            key = self.tables["keys"]()
             key.key_id = constraint_name
             key.from_table = first_column.table_name
             key.target_table = first_refcolumn.table_name
             key.description = description
             key.utype = utype
             for column, refcolumn in zip(columns, refcolumns):
-                key_column = Tap11KeyColumns()
+                key_column = self.tables["key_columns"]()
                 key_column.key_id = constraint_name
                 key_column.from_column = column.column_name
                 key_column.target_column = refcolumn.column_name
@@ -264,9 +272,7 @@ class TapLoadingVisitor(VisitorBase):
 
     def visit_index(self, index_obj, table_obj):
         self.check_index(index_obj, table_obj)
-        columns = [
-            self.graph_index[c_id] for c_id in index_obj.get("columns", [])
-        ]
+        columns = [self.graph_index[c_id] for c_id in index_obj.get("columns", [])]
         # if just one column and it's indexed, update the object
         if len(columns) == 1:
             columns[0].indexed = 1


### PR DESCRIPTION
This adds a few different options for overriding the names of the TAP tables, either individually or with a postfix option (`--tap-tables-postfix`).

This also fixes a few issues around felis file merging as well provides an small example for merging.